### PR TITLE
Fixes deployment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,41 @@ Snapshot -->> HashTagActor: get counts from actor
 ```
 
 TODO what about Pubsub Workflow ? who is publishing to it? And validation workflow?
+
+# Deploying this application
+
+## Locally with docker-compose or `dapr run -f`
+
+TBD -- does it even work?
+
+## On Azure Kubernetes Service (AKS)
+
+Define the resource group we in which will we create the cluster and other resources and
+the name of the cluster we will create.
+
+```bash
+export resourceGroup='myNewResourceGroup'
+export location='eastus'
+export clusterName='test-infra'
+```
+
+Create a resource group four your new cluster
+
+```bash
+az group create --name ${resourceGroup} --location ${location}
+```
+
+Deploy a cluster with test apps to this resource group:
+
+```bash
+az deployment group create --resource-group ${resourceGroup} --template-file ./deploy/aks/main.bicep --parameters "clusterName=${clusterName}"
+```
+
+
+Done! Explore your new AKS cluster with the sample applications
+
+```bash
+az aks get-credentials --admin --name ${clusterName} --resource-group $resourceGroup
+```
+
+## On Azure Container Apps (ACA)

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ az deployment group create --resource-group ${resourceGroup} --template-file ./d
 Done! Explore your new AKS cluster with the sample applications
 
 ```bash
-az aks get-credentials --admin --name ${clusterName} --resource-group $resourceGroup
+az aks get-credentials --admin --name ${clusterName} --resource-group ${resourceGroup}
 ```
 
 ## On Azure Container Apps (ACA)

--- a/README.md
+++ b/README.md
@@ -7,3 +7,12 @@ This repo includes test apps and infrastructure tools.
 * [HashTag Counter](./hashtag-counter) : Test app for long haul test, contains hashtag-counter.
 * [HashTag Actor](./hashtag-actor) : Test app for long haul test, hashtag-actor logic.
 * [Pubsub Workflow](./pubsub-workflow) : Test app for long haul test, azure service bus pubsub logic.
+
+# Solution overview and app dependency
+
+```mermaid
+sequenceDiagram
+FeedGenerator -->> MessageAnalyzer : publish a SocialMediaMessage async using pubsub
+MessageAnalyzer -->> HashTagCounter: invoke a binding publish message to a StorageQueue
+HashTagCounter ->> HashTagActor: increase counter in message's hashtag's actor
+```

--- a/README.md
+++ b/README.md
@@ -15,4 +15,8 @@ sequenceDiagram
 FeedGenerator -->> MessageAnalyzer : publish a SocialMediaMessage async using pubsub
 MessageAnalyzer -->> HashTagCounter: invoke a binding publish message to a StorageQueue
 HashTagCounter ->> HashTagActor: increase counter in message's hashtag's actor
+
+Snapshot -->> HashTagActor: get counts from actor
 ```
+
+TODO what about Pubsub Workflow ? who is publishing to it? And validation workflow?

--- a/deploy/aks/daprComponents/cosmos-component.bicep
+++ b/deploy/aks/daprComponents/cosmos-component.bicep
@@ -11,11 +11,6 @@ import 'kubernetes@1.0.0' with {
   kubeConfig: kubeConfig
 }
 
-// resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2023-04-15' existing = {
-//   name: cosmosAccountName
-//   scope: resourceGroup()
-// }
-
 resource daprIoComponentStatestore 'dapr.io/Component@v1alpha1' = {
   metadata: {
     name: 'statestore'

--- a/deploy/aks/daprComponents/cosmos-component.bicep
+++ b/deploy/aks/daprComponents/cosmos-component.bicep
@@ -1,7 +1,6 @@
 @secure()
 param kubeConfig string
 param kubernetesNamespace string
-param cosmosAccountName string
 param cosmosUrl string
 param cosmosDatabaseName string
 param cosmosContainerName string
@@ -17,7 +16,7 @@ import 'kubernetes@1.0.0' with {
 //   scope: resourceGroup()
 // }
 
-resource daprIoComponent_statestore 'dapr.io/Component@v1alpha1' = {
+resource daprIoComponentStatestore 'dapr.io/Component@v1alpha1' = {
   metadata: {
     name: 'statestore'
     namespace: kubernetesNamespace

--- a/deploy/aks/daprComponents/cosmos-component.bicep
+++ b/deploy/aks/daprComponents/cosmos-component.bicep
@@ -5,15 +5,17 @@ param cosmosAccountName string
 param cosmosUrl string
 param cosmosDatabaseName string
 param cosmosContainerName string
+param cosmosAccountPrimaryMasterKey string
 
 import 'kubernetes@1.0.0' with {
   namespace: 'default'
   kubeConfig: kubeConfig
 }
 
-resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2023-04-15' existing = {
-  name: cosmosAccountName
-}
+// resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2023-04-15' existing = {
+//   name: cosmosAccountName
+//   scope: resourceGroup()
+// }
 
 resource daprIoComponent_statestore 'dapr.io/Component@v1alpha1' = {
   metadata: {
@@ -30,7 +32,7 @@ resource daprIoComponent_statestore 'dapr.io/Component@v1alpha1' = {
       }
       {
         name: 'masterKey'
-        value: cosmos.listKeys().primaryMasterKey
+        value: cosmosAccountPrimaryMasterKey
       }
       {
         name: 'database'

--- a/deploy/aks/daprComponents/servicebus-pubsub-component.bicep
+++ b/deploy/aks/daprComponents/servicebus-pubsub-component.bicep
@@ -1,0 +1,79 @@
+@secure()
+param kubeConfig string
+param kubernetesNamespace string
+
+@secure()
+param serviceBusConnectionString string
+
+import 'kubernetes@1.0.0' with {
+  namespace: 'default'
+  kubeConfig: kubeConfig
+}
+
+resource daprIoComponent_longhaulSbRapid 'dapr.io/Component@v1alpha1' = {
+  metadata: {
+    name: 'longhaul-sb-rapid'
+    namespace: kubernetesNamespace
+  }
+  spec: {
+    type: 'pubsub.azure.servicebus'
+    version: 'v1'
+    metadata: [
+      {
+        name: 'connectionString'
+        value: serviceBusConnectionString
+      }
+    ]
+  }
+}
+
+resource daprIoComponent_longhaulSbMedium 'dapr.io/Component@v1alpha1' = {
+  metadata: {
+    name: 'longhaul-sb-medium'
+    namespace: kubernetesNamespace
+  }
+  spec: {
+    type: 'pubsub.azure.servicebus'
+    version: 'v1'
+    metadata: [
+      {
+        name: 'connectionString'
+        value: serviceBusConnectionString
+      }
+    ]
+  }
+}
+
+resource daprIoComponent_longhaulSbSlow 'dapr.io/Component@v1alpha1' = {
+  metadata: {
+    name: 'longhaul-sb-slow'
+    namespace: kubernetesNamespace
+  }
+  spec: {
+    type: 'pubsub.azure.servicebus'
+    version: 'v1'
+    metadata: [
+      {
+        name: 'connectionString'
+        value: serviceBusConnectionString
+      }
+    ]
+  }
+}
+
+resource daprIoComponent_longhaulSbGlacial 'dapr.io/Component@v1alpha1' = {
+  metadata: {
+    name: 'longhaul-sb-glacial'
+    namespace: kubernetesNamespace
+  }
+  spec: {
+    type: 'pubsub.azure.servicebus'
+    version: 'v1'
+    metadata: [
+      {
+        name: 'connectionString'
+        value: serviceBusConnectionString
+      }
+    ]
+  }
+}

--- a/deploy/aks/daprComponents/servicebus-pubsub-component.bicep
+++ b/deploy/aks/daprComponents/servicebus-pubsub-component.bicep
@@ -10,43 +10,20 @@ import 'kubernetes@1.0.0' with {
   kubeConfig: kubeConfig
 }
 
-resource daprIoComponent_longhaulSbRapid 'dapr.io/Component@v1alpha1' = {
-  metadata: {
-    name: 'longhaul-sb-rapid'
-    namespace: kubernetesNamespace
-  }
-  spec: {
-    type: 'pubsub.azure.servicebus'
-    version: 'v1'
-    metadata: [
-      {
-        name: 'connectionString'
-        value: serviceBusConnectionString
-      }
-    ]
-  }
-}
+param allPubSubTopicNames array = [
+  'receivemediapost'
+  'longhaul-sb-rapid'
+  'longhaul-sb-medium'
+  'longhaul-sb-slow'
+  'longhaul-sb-glacial'
+]
 
-resource daprIoComponent_longhaulSbMedium 'dapr.io/Component@v1alpha1' = {
-  metadata: {
-    name: 'longhaul-sb-medium'
-    namespace: kubernetesNamespace
-  }
-  spec: {
-    type: 'pubsub.azure.servicebus'
-    version: 'v1'
-    metadata: [
-      {
-        name: 'connectionString'
-        value: serviceBusConnectionString
-      }
-    ]
-  }
-}
 
-resource daprIoComponent_longhaulSbSlow 'dapr.io/Component@v1alpha1' = {
+// We need a few pubsubs for our applications. They have different purposes
+// but are functionally the same. We can use a loop to create them all at once.
+resource daprserviceBusPubSubComponents 'dapr.io/Component@v1alpha1' = [for pubsubName in allPubSubTopicNames: {
   metadata: {
-    name: 'longhaul-sb-slow'
+    name: pubsubName
     namespace: kubernetesNamespace
   }
   spec: {
@@ -59,21 +36,4 @@ resource daprIoComponent_longhaulSbSlow 'dapr.io/Component@v1alpha1' = {
       }
     ]
   }
-}
-
-resource daprIoComponent_longhaulSbGlacial 'dapr.io/Component@v1alpha1' = {
-  metadata: {
-    name: 'longhaul-sb-glacial'
-    namespace: kubernetesNamespace
-  }
-  spec: {
-    type: 'pubsub.azure.servicebus'
-    version: 'v1'
-    metadata: [
-      {
-        name: 'connectionString'
-        value: serviceBusConnectionString
-      }
-    ]
-  }
-}
+}]

--- a/deploy/aks/daprComponents/storage-queue-component.bicep
+++ b/deploy/aks/daprComponents/storage-queue-component.bicep
@@ -1,0 +1,38 @@
+@secure()
+param kubeConfig string
+param kubernetesNamespace string
+@secure()
+param storageAccountKey string
+param storageAccountName string
+param storageQueueName string
+
+
+import 'kubernetes@1.0.0' with {
+  namespace: 'default'
+  kubeConfig: kubeConfig
+}
+
+resource daprIoComponent_messagebinding 'dapr.io/Component@v1alpha1' = {
+  metadata: {
+    name: 'messagebinding'
+    namespace: kubernetesNamespace
+  }
+  spec: {
+    type: 'bindings.azure.storagequeues'
+    version: 'v1'
+    metadata: [
+      {
+        name: 'storageAccount'
+        value: storageAccountName
+      }
+      {
+        name: 'accountKey'
+        value: storageAccountKey
+      }
+      {
+        name: 'queue'
+        value: storageQueueName
+      }
+    ]
+  }
+}

--- a/deploy/aks/daprComponents/storage-queue-component.bicep
+++ b/deploy/aks/daprComponents/storage-queue-component.bicep
@@ -12,7 +12,7 @@ import 'kubernetes@1.0.0' with {
   kubeConfig: kubeConfig
 }
 
-resource daprIoComponent_messagebinding 'dapr.io/Component@v1alpha1' = {
+resource daprIoComponentMessageBinding 'dapr.io/Component@v1alpha1' = {
   metadata: {
     name: 'messagebinding'
     namespace: kubernetesNamespace

--- a/deploy/aks/parameters.json
+++ b/deploy/aks/parameters.json
@@ -5,32 +5,8 @@
     "clusterName": {
       "value": "tmacam-lh-test-cluster"
     },
-    "identityName": {
-      "value": "tmacam-lh-identity"
-    },
-    "storageAccountName": {
-      "value": "tmacamlhstorage"
-    },
-    "serviceBusNamespace": {
-      "value": "tmacamlhsb"
-    },
-    "kubernetesNamespace": {
-      "value": "longhaul-test"
-    },
-    "grafanaName": {
-      "value": "tmacam-lh-grafana"
-    },
-    "amwName": {
-      "value": "tmacam-lh-amw"
-    },
-    "logAnalyticsName": {
-      "value": "tmacam-lh-la"
-    },
-    "userGrafanaAdminObjectId": {
-      "value": "b92bc7c4-11f0-4e38-b49f-58621e50c3e5"
-    },
-    "queueName": {
-      "value": "longhaulqueue"
+    "shortClusterPrefixId": {
+      "value": "tlh"
     }
   }
 }

--- a/deploy/aks/parameters.json
+++ b/deploy/aks/parameters.json
@@ -3,31 +3,28 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "clusterName": {
-      "value": "halspang-lh-test-cluster"
+      "value": "tmacam-lh-test-cluster"
     },
     "identityName": {
-      "value": "halspang-lh-identity"
+      "value": "tmacam-lh-identity"
     },
     "storageAccountName": {
-      "value": "halspanglhstorage"
-    },
-    "cosmosAccountName": {
-      "value": "halspanglhcosmos"
+      "value": "tmacamlhstorage"
     },
     "serviceBusNamespace": {
-      "value": "halspanglhsb"
+      "value": "tmacamlhsb"
     },
     "kubernetesNamespace": {
       "value": "longhaul-test"
     },
     "grafanaName": {
-      "value": "halspang-lh-grafana"
+      "value": "tmacam-lh-grafana"
     },
     "amwName": {
-      "value": "halspang-lh-amw"
+      "value": "tmacam-lh-amw"
     },
     "logAnalyticsName": {
-      "value": "halspang-lh-la"
+      "value": "tmacam-lh-la"
     },
     "userGrafanaAdminObjectId": {
       "value": "b92bc7c4-11f0-4e38-b49f-58621e50c3e5"

--- a/deploy/aks/parameters.json
+++ b/deploy/aks/parameters.json
@@ -3,10 +3,10 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "clusterName": {
-      "value": "tmacam-lh-test-cluster"
+      "value": "longhaul-release-cluster"
     },
     "shortClusterPrefixId": {
-      "value": "tlh"
+      "value": "lr"
     }
   }
 }

--- a/deploy/aks/services/cosmos.bicep
+++ b/deploy/aks/services/cosmos.bicep
@@ -1,17 +1,20 @@
+param solutionName string
 
-param cosmosAccountName string
-param cosmosDatabaseName string = 'longhauldb'
-param cosmosContainerName string = 'longhaulcontainer'
 param location string
 param principalId string
-param roleDefinitionName string = 'dataRole'
-param dataActions array = [
+
+param cosmosAccountName string = '${solutionName}-cosmos'
+param cosmosDatabaseName string = '${solutionName}-db'
+param cosmosContainerName string = '${solutionName}-container'
+
+var roleDefinitionName  = 'dataRole'
+var dataActions  = [
   'Microsoft.DocumentDB/databaseAccounts/readMetadata'
   'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/items/*'
 ]
 
 resource cosmosAccount 'Microsoft.DocumentDB/databaseAccounts@2023-04-15' = {
-  name: cosmosAccountName
+  name: toLower(cosmosAccountName)
   location: location
   properties: {
     databaseAccountOfferType: 'Standard'
@@ -22,6 +25,8 @@ resource cosmosAccount 'Microsoft.DocumentDB/databaseAccounts@2023-04-15' = {
     ]
   }
 }
+
+var cosmosAccountPrimaryMasterKey = cosmosAccount.listKeys().primaryMasterKey
 
 resource cosmosDatabase 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2021-10-15' = {
   parent: cosmosAccount
@@ -94,6 +99,7 @@ resource sqlRoleAssignment 'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignm
 }
 
 output cosmosUrl string = cosmosAccount.properties.documentEndpoint
-output cosmosAccountName string = cosmosAccountName
-output cosmosDatabaseName string = 'longhauldb'
-output cosmosContainerName string = 'longhaulcontainer'
+output cosmosAccountName string = cosmosAccount.name
+output cosmosDatabaseName string = cosmosDatabase.name
+output cosmosContainerName string = cosmosContainer.name
+output cosmosAccountPrimaryMasterKey string = cosmosAccountPrimaryMasterKey

--- a/deploy/aks/services/namespace.bicep
+++ b/deploy/aks/services/namespace.bicep
@@ -12,3 +12,6 @@ resource longhaulNamespace 'core/Namespace@v1' = {
     name: kubernetesNamespace
   }
 }
+
+@description('The name of the k8s namespace to use. This exists only to provide an implicit dependency')
+output kubernetesNamespace string = longhaulNamespace.metadata.name

--- a/deploy/aks/services/servicebus.bicep
+++ b/deploy/aks/services/servicebus.bicep
@@ -1,13 +1,7 @@
-@secure()
-param kubeConfig string
 param serviceBusNamespace string
 param location string
 param principalId string
 
-import 'kubernetes@1.0.0' with {
-  namespace: 'default'
-  kubeConfig: kubeConfig
-}
 
 resource servicebus 'Microsoft.ServiceBus/namespaces@2021-11-01' = {
   name: serviceBusNamespace

--- a/deploy/aks/services/servicebus.bicep
+++ b/deploy/aks/services/servicebus.bicep
@@ -36,74 +36,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
 
 
 var serviceBusEndpoint = '${servicebus.id}/AuthorizationRules/RootManageSharedAccessKey'
-var connectionString = listKeys(serviceBusEndpoint, servicebus.apiVersion).primaryConnectionString
 
-resource daprIoComponent_longhaulSbRapid 'dapr.io/Component@v1alpha1' = {
-  metadata: {
-    name: 'longhaul-sb-rapid'
-    namespace: kubernetesNamespace
-  }
-  spec: {
-    type: 'pubsub.azure.servicebus'
-    version: 'v1'
-    metadata: [
-      {
-        name: 'connectionString'
-        value: connectionString
-      }
-    ]
-  }
-}
 
-resource daprIoComponent_longhaulSbMedium 'dapr.io/Component@v1alpha1' = {
-  metadata: {
-    name: 'longhaul-sb-medium'
-    namespace: kubernetesNamespace
-  }
-  spec: {
-    type: 'pubsub.azure.servicebus'
-    version: 'v1'
-    metadata: [
-      {
-        name: 'connectionString'
-        value: connectionString
-      }
-    ]
-  }
-}
-
-resource daprIoComponent_longhaulSbSlow 'dapr.io/Component@v1alpha1' = {
-  metadata: {
-    name: 'longhaul-sb-slow'
-    namespace: kubernetesNamespace
-  }
-  spec: {
-    type: 'pubsub.azure.servicebus'
-    version: 'v1'
-    metadata: [
-      {
-        name: 'connectionString'
-        value: connectionString
-      }
-    ]
-  }
-}
-
-resource daprIoComponent_longhaulSbGlacial 'dapr.io/Component@v1alpha1' = {
-  metadata: {
-    name: 'longhaul-sb-glacial'
-    namespace: kubernetesNamespace
-  }
-  spec: {
-    type: 'pubsub.azure.servicebus'
-    version: 'v1'
-    metadata: [
-      {
-        name: 'connectionString'
-        value: connectionString
-      }
-    ]
-  }
-}
-
-output servicebusNamespace string = serviceBusNamespace
+output serviceBusConnectionString string = listKeys(serviceBusEndpoint, servicebus.apiVersion).primaryConnectionString
+output serviceBusNamespace string = serviceBusNamespace

--- a/deploy/aks/services/servicebus.bicep
+++ b/deploy/aks/services/servicebus.bicep
@@ -1,6 +1,5 @@
 @secure()
 param kubeConfig string
-param kubernetesNamespace string
 param serviceBusNamespace string
 param location string
 param principalId string

--- a/deploy/aks/services/storage-services.bicep
+++ b/deploy/aks/services/storage-services.bicep
@@ -21,18 +21,22 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2021-09-01' = {
   kind: 'StorageV2'
 }
 
+var storageAccountKey = storageAccount.listKeys(storageAccount.apiVersion).keys[0].value
+
+
 resource storagequeue 'Microsoft.Storage/storageAccounts/queueServices@2021-09-01' = {
-  name: 'default'
+  name: 'default' // TODO(tmacam) parameterize
   parent: storageAccount
 }
 
 resource blobstore 'Microsoft.Storage/storageAccounts/blobServices@2021-09-01' = {
-  name: 'default'
+  name: 'default'  // TODO(tmacam) parameterize
   parent: storageAccount
 }
 
 resource storageServiceContributorRoleDefinition 'Microsoft.Authorization/roleDefinitions@2022-04-01' existing = {
   scope: subscription()
+   // TODO(tmacam) What is this value?!
   name: '17d1049b-9a84-46fb-8f53-869881c3d3ab' // GUID for storage account contributor.
 }
 
@@ -45,30 +49,9 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   }
 }
 
-resource daprIoComponent_messagebinding 'dapr.io/Component@v1alpha1' = {
-  metadata: {
-    name: 'messagebinding'
-    namespace: kubernetesNamespace
-  }
-  spec: {
-    type: 'bindings.azure.storagequeues'
-    version: 'v1'
-    metadata: [
-      {
-        name: 'storageAccount'
-        value: accountName
-      }
-      {
-        name: 'accountKey'
-        value: storageAccount.listKeys(storageAccount.apiVersion).keys[0].value
-      }
-      {
-        name: 'queue'
-        value: queueName
-      }
-    ]
-  }
-}
 
-output location string = location
-output accountName string = accountName
+// output location string = location
+// output accountName string = storageAccount.name
+output storageAccountKey string = storageAccountKey
+output storageAccountName string = storageAccount.name
+output storageQueueName string = storagequeue.name

--- a/deploy/aks/services/storage-services.bicep
+++ b/deploy/aks/services/storage-services.bicep
@@ -1,10 +1,8 @@
 @secure()
 param kubeConfig string
-param kubernetesNamespace string
 param location string
 param accountName string
 param principalId string
-param queueName string
 
 import 'kubernetes@1.0.0' with {
   namespace: 'default'
@@ -25,12 +23,12 @@ var storageAccountKey = storageAccount.listKeys(storageAccount.apiVersion).keys[
 
 
 resource storagequeue 'Microsoft.Storage/storageAccounts/queueServices@2021-09-01' = {
-  name: 'default' // TODO(tmacam) parameterize
+  name: 'default'
   parent: storageAccount
 }
 
 resource blobstore 'Microsoft.Storage/storageAccounts/blobServices@2021-09-01' = {
-  name: 'default'  // TODO(tmacam) parameterize
+  name: 'default'
   parent: storageAccount
 }
 
@@ -50,8 +48,6 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
 }
 
 
-// output location string = location
-// output accountName string = storageAccount.name
 output storageAccountKey string = storageAccountKey
 output storageAccountName string = storageAccount.name
 output storageQueueName string = storagequeue.name

--- a/deploy/aks/services/storage-services.bicep
+++ b/deploy/aks/services/storage-services.bicep
@@ -1,13 +1,7 @@
-@secure()
-param kubeConfig string
 param location string
 param accountName string
 param principalId string
 
-import 'kubernetes@1.0.0' with {
-  namespace: 'default'
-  kubeConfig: kubeConfig
-}
 
 // Storage account and associated services.
 resource storageAccount 'Microsoft.Storage/storageAccounts@2021-09-01' = {


### PR DESCRIPTION
The general strategy is: avoid `existing` references and just
pass secrets around using outputs and params.

Problematic? Yes.

Does it work? Yes.

Would using `existing` references be better? Yes, if they worked but
they don't. Even inlining components and wrapping the calls that return
secrets into variables causes odd, odd errors so no, we are passing
them around.

What errors are you talking about? For future-self, this kind of errors when using `existing`

```
'The resource 'Microsoft.ServiceBus/namespaces/tmacamlhsb/AuthorizationRules/RootManageSharedAccessKey' is not defined in the template.
```

and this one when you attempt to inline things and wrap secrets in
variables:

```
An unknown error has occurred. (Code: UnknownFailure, Target: daprIoComponent_messagebinding)
```

We could avoid passing secrets around if we constructed Dapr Components
templates from within services templates. Secrets would still be provided
as parameters but not turned into outputs. Or if we wrapped them in
secrets. Or even better: used AAD for authentication. But thats for the
future.

Next steps:
* General code cleanup
* Get a bit opinionated about the naming of parameters and set defaults
  for them so we don't need anything in parameters.json
* Add inter-app deployment dependencies

Signed-off-by: Tiago Alves Macambira <tmacam@burocrata.org>

# Description

_Please explain the changes you've made_

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
